### PR TITLE
fix pm2 command sequence

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -41,14 +41,6 @@ if (process.platform === "linux" || process.platform === "darwin") {
 
     // pm2
 
-    child_process.execSync("pm2 start processes.json", {
-        stdio: [
-            null,
-            process.stdout,
-            process.stderr
-        ]
-    });
-
     let platform = "";
 
     if (fs.existsSync("/usr/bin/systemctl") === true) {
@@ -63,6 +55,14 @@ if (process.platform === "linux" || process.platform === "darwin") {
     }
 
     child_process.execSync(`pm2 startup ${platform}`, {
+        stdio: [
+            null,
+            process.stdout,
+            process.stderr
+        ]
+    });
+
+    child_process.execSync("pm2 start processes.json", {
         stdio: [
             null,
             process.stdout,


### PR DESCRIPTION
slackで言っていた、systemd環境でMirakurunのアップデートを行うとdump.pm2が高い確率で空になってしまい、Mirakurunが自動的に起動しなくなる場合がある件の修正です。
