### PR TITLE
Add Gentoo/OpenRC support

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -47,6 +47,8 @@ if (process.platform === "linux" || process.platform === "darwin") {
         platform = "systemd";
     } if (fs.existsSync("/etc/redhat-release") === true) {
         platform = "centos";
+    } else if (fs.existsSync("/etc/gentoo-release") === true) {
+        platform = "gentoo";
     } else if (fs.existsSync("/etc/issue") === true) {
         const issue = fs.readFileSync("/etc/issue", { encoding: "utf-8" });
         if (/Ubuntu/.test(issue) === true) {


### PR DESCRIPTION
Gentoo/OpenRCサポートのため判定を追加します。
PM2の既知の問題のため動作にはpm2 V2.0系のインストールが必要となります。
インストール方法
`npm install pm2@next -g`
