### PR TITLE
Improve PT2 support

### DIFF
--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -59,7 +59,7 @@ export default class TunerDevice extends events.EventEmitter {
     private _isAvailable: boolean = true;
     private _exited: boolean = false;
     private _closing: boolean = false;
-    private _pt2Resolver: (value?: {} | PromiseLike<{}>) => void = () => {};
+    private _pt2Resolver: () => void = () => {};
 
     constructor(private _index: number, private _config: config.Tuner) {
         super();

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -59,7 +59,7 @@ export default class TunerDevice extends events.EventEmitter {
     private _isAvailable: boolean = true;
     private _exited: boolean = false;
     private _closing: boolean = false;
-    private _pt2Resolver: (value?: {} | PromiseLike<{}>) => void = () => {};
+    private _pt2Resolver = () => {};
 
     constructor(private _index: number, private _config: config.Tuner) {
         super();

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -421,4 +421,4 @@ export default class TunerDevice extends events.EventEmitter {
     private _updated(): void {
         Event.emit("tuner", "update", this.export());
     }
-}
+}

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -230,8 +230,8 @@ export default class TunerDevice extends events.EventEmitter {
                         resolve();
                         setTimeout(_resolve, 500);
                     });
-                }).then(() => this.__spawn(ch));
-            });
+                });
+            }).then(() => this.__spawn(ch));
         } else {
             // regular way
             return this.__spawn(ch);

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -228,7 +228,7 @@ export default class TunerDevice extends events.EventEmitter {
                 pt2Queue.add(() => {
                     return new Promise(_resolve => {
                         resolve();
-                        setTimeout(_resolve, 500);
+                        setTimeout(_resolve, 4000);
                     });
                 });
             }).then(() => this.__spawn(ch));

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -234,12 +234,13 @@ export default class TunerDevice extends events.EventEmitter {
                     });
                 });
             }).then(() => {
-                this.__spawn(ch);
+                let ret = this.__spawn(ch);
                 this._process.stderr.on("data", data => {
                     if (data.toString().match(/Recording\.\.\./)) {
                         pt2Resolver();
                     }
                 });
+                return ret;
             });
         } else {
             // regular way

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -236,7 +236,7 @@ export default class TunerDevice extends events.EventEmitter {
             }).then(() => {
                 this.__spawn(ch);
                 this._process.stderr.on("data", data => {
-                    if (data.toString().match("Recording...")) {
+                    if (data.toString().match(/Recording\.\.\./)) {
                         pt2Resolver();
                     }
                 });

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -59,7 +59,7 @@ export default class TunerDevice extends events.EventEmitter {
     private _isAvailable: boolean = true;
     private _exited: boolean = false;
     private _closing: boolean = false;
-    private _pt2Resolver: () => void = () => {};
+    private _pt2Resolver: (value?: {} | PromiseLike<{}>) => void = () => {};
 
     constructor(private _index: number, private _config: config.Tuner) {
         super();

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -59,6 +59,7 @@ export default class TunerDevice extends events.EventEmitter {
     private _isAvailable: boolean = true;
     private _exited: boolean = false;
     private _closing: boolean = false;
+    private _pt2Resolver: (value?: {} | PromiseLike<{}>) => void = () => {};
 
     constructor(private _index: number, private _config: config.Tuner) {
         super();
@@ -228,6 +229,7 @@ export default class TunerDevice extends events.EventEmitter {
                 pt2Queue.add(() => {
                     return new Promise(_resolve => {
                         resolve();
+                        this._pt2Resolver = _resolve;
                         setTimeout(_resolve, 4000);
                     });
                 });
@@ -309,6 +311,9 @@ export default class TunerDevice extends events.EventEmitter {
         });
 
         this._process.stderr.on("data", data => {
+            if (data.toString().match("Recording...")) {
+                this._pt2Resolver();
+            }
             log.info("TunerDevice#%d > %s", this._index, data.toString().trim());
         });
 

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -421,4 +421,4 @@ export default class TunerDevice extends events.EventEmitter {
     private _updated(): void {
         Event.emit("tuner", "update", this.export());
     }
-}
+}


### PR DESCRIPTION
現状ではコマンド起動のすぐ後にSIGTERMを送ることがあり、これがデバイスファイルが使えなくなる現象の原因になるので修正しました。
また、放送波の来ていないチャンネルに合わせると勝手にコマンドが終了して、SIGTERMの送信タイミングとかぶる場合があります。放送波が来ていないチャンネルに合わせると3.5秒ほどで自動終了するので、少し長めの4秒はSIGTERMを送ることがないようにしました。