### PR TITLE
bin: postinstall: remove our own init detector for pm2

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -41,22 +41,7 @@ if (process.platform === "linux" || process.platform === "darwin") {
 
     // pm2
 
-    let platform = "";
-
-    if (fs.existsSync("/usr/bin/systemctl") === true) {
-        platform = "systemd";
-    } if (fs.existsSync("/etc/redhat-release") === true) {
-        platform = "centos";
-    } else if (fs.existsSync("/etc/gentoo-release") === true) {
-        platform = "gentoo";
-    } else if (fs.existsSync("/etc/issue") === true) {
-        const issue = fs.readFileSync("/etc/issue", { encoding: "utf-8" });
-        if (/Ubuntu/.test(issue) === true) {
-            platform = "ubuntu";
-        }
-    }
-
-    child_process.execSync(`pm2 startup ${platform}`, {
+    child_process.execSync(`pm2 startup`, {
         stdio: [
             null,
             process.stdout,


### PR DESCRIPTION
pm2自身のシステム検出にまかせてみようという趣旨のPull Requestです。
Mirakurun独自の検出では、Ubuntu 14.04などでもubuntuを検出します。`pm2 startup ubuntu`はsystemctlを使用するため、Ubuntu 14以前のシステムではインストールが失敗します。