### PR TITLE
チューニング空間を数値で指定できるように追加しました。

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -43,7 +43,9 @@ export interface Channel {
     channel: string;
     name?: string;
     satelite?: string;
+    space?: number;
     services?: Service[];
+
 }
 
 export type ChannelType = "GR" | "BS" | "CS" | "SKY";

--- a/api.d.ts
+++ b/api.d.ts
@@ -45,7 +45,6 @@ export interface Channel {
     satelite?: string;
     space?: number;
     services?: Service[];
-
 }
 
 export type ChannelType = "GR" | "BS" | "CS" | "SKY";

--- a/api.yml
+++ b/api.yml
@@ -78,6 +78,8 @@ definitions:
         type: string
       satelite:
         type: string
+      space:
+        type: number
       services:
         type: array
         items:

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -81,6 +81,7 @@ sudo mirakurun config channels
   # below are optional
   serviceId: 1234 # integer
   satelite: JCSAT4A # string for <satelite> in tuner command
+  space: 0 # Tuning space number, which replaces <space> in tuner command (as integer; set to 0 if isn't specified)
   isDisabled: false # boolean
 ```
 

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -81,7 +81,7 @@ sudo mirakurun config channels
   # below are optional
   serviceId: 1234 # integer
   satelite: JCSAT4A # string for <satelite> in tuner command
-  space: 0 # Tuning space number, which replaces <space> in tuner command (as integer; set to 0 if isn't specified)
+  space: 0 # integer: <space> as tuning space number in tuner command (default: 0)
   isDisabled: false # boolean
 ```
 

--- a/src/Mirakurun/Channel.ts
+++ b/src/Mirakurun/Channel.ts
@@ -101,6 +101,11 @@ export default class Channel {
                 return;
             }
 
+            if (channel.space && typeof channel.space !== "number") {
+                log.error("invalid type of property `space` in channel#%d (%s) configuration", i, channel.name);
+                return;
+            }
+
             if (channel.serviceId && typeof channel.serviceId !== "number") {
                 log.error("invalid type of property `serviceId` in channel#%d (%s) configuration", i, channel.name);
                 return;

--- a/src/Mirakurun/ChannelItem.ts
+++ b/src/Mirakurun/ChannelItem.ts
@@ -31,6 +31,7 @@ export default class ChannelItem {
     private _type: common.ChannelType;
     private _channel: string;
     private _satelite: string;
+    private _space: number;
 
     constructor(config: config.Channel) {
 
@@ -47,6 +48,7 @@ export default class ChannelItem {
         this._type = config.type;
         this._channel = config.channel;
         this._satelite = config.satelite;
+        this._space = config.space;
 
         if (config.serviceId) {
             this.addService(config.serviceId);
@@ -79,12 +81,17 @@ export default class ChannelItem {
         return this._satelite;
     }
 
+    get space(): number {
+        return this._space;
+    }
+
     export(): config.Channel {
         return {
             type: this._type,
             channel: this._channel,
             name: this._name,
-            satelite: this._satelite
+            satelite: this._satelite,
+            space: this._space
         };
     }
 

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -230,7 +230,7 @@ export default class TunerDevice extends events.EventEmitter {
         }
 
         if (ch.space) {
-            cmd = cmd.replace("<space>", ch.space.toString());
+            cmd = cmd.replace("<space>", ch.space.toString(10));
         } else {
             cmd = cmd.replace("<space>", "0"); // set default value to '0'
         }

--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -229,6 +229,12 @@ export default class TunerDevice extends events.EventEmitter {
             cmd = cmd.replace("<satelite>", ch.satelite);
         }
 
+        if (ch.space) {
+            cmd = cmd.replace("<space>", ch.space.toString());
+        } else {
+            cmd = cmd.replace("<space>", "0"); // set default value to '0'
+        }
+
         this._process = child_process.spawn(cmd.split(" ")[0], cmd.split(" ").slice(1));
         this._command = cmd;
         this._channel = ch;

--- a/src/Mirakurun/config.ts
+++ b/src/Mirakurun/config.ts
@@ -72,6 +72,7 @@ export interface Channel {
     // passed to tuning command
     readonly channel: string;
     readonly satelite?: string;
+    readonly space?: number;
 
     // service id
     readonly serviceId?: number;


### PR DESCRIPTION
BonRecTest等をチューナーとして設定する際、
`bonrectest --driver hoge --channel <channel> **--space <space>** ~~`
としてチューニング空間を指定できるようにしました。
channels.ymlで`space: [0-9]+`とすることで流し込まれます。

channelsで未指定、かつチューナーに<space>があった場合は0として処理されます。