### PR TITLE
postinstall: fix pm2 version check

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -71,7 +71,7 @@ if (process.platform === "linux" || process.platform === "darwin") {
     }
 
     // pm2 check
-    const pm2Version = child_process.execSync("pm2 -v", { encoding: "utf8" }).trim();
+    const pm2Version = child_process.execSync("pm2 -version", { encoding: "utf8" }).trim();
     const pm2Expected = ">=2.4.0 <3.0.0";
     if (semver.satisfies(pm2Version, pm2Expected) === true) {
         console.log("Version:", `pm2@${pm2Version}`, "[OK]");


### PR DESCRIPTION
### Environment
* Version of Mirakurun: `2.5.3`
* Version of Node: `v6.10.3-r0`
* Version of NPM: `v6.10.3-r0`
* Version of PM2: `2.4.6`
* Platform:
  * Architecture: x64
  * Docker: 17.05.0-ce

### Issue
2.4.0からversion表示時のメッセージが変わっており、文字数超過の為エラーとなる模様です
「-version」で試したところ、インストール可能でしたのでmergeをお願いします
```
/usr/lib/node_modules/mirakurun/node_modules/semver/semver.js:283
    throw new TypeError('version is longer than ' + MAX_LENGTH + ' characters')
    ^

TypeError: version is longer than 256 characters
    at new SemVer (/usr/lib/node_modules/mirakurun/node_modules/semver/semver.js:283:11)
    at Range.test (/usr/lib/node_modules/mirakurun/node_modules/semver/semver.js:1036:15)
    at Function.satisfies (/usr/lib/node_modules/mirakurun/node_modules/semver/semver.js:1085:16)
    at Object.<anonymous> (/usr/lib/node_modules/mirakurun/bin/postinstall.js:76:16)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
```

参考に該当のcommit履歴も置いておきます
https://github.com/Unitech/pm2/commit/0826fcb1b757c5e1881235615860c7a2e7f90bb3
```shell
/ # pm2 -v

                        -------------

                      PM2 process manager

__/\\\\\\\\\\\\\____/\\\\____________/\\\\____/\\\\\\\\\_____
 _\/\\\/////////\\\_\/\\\\\\________/\\\\\\__/\\\///////\\\___
  _\/\\\_______\/\\\_\/\\\//\\\____/\\\//\\\_\///______\//\\\__
   _\/\\\\\\\\\\\\\/__\/\\\\///\\\/\\\/_\/\\\___________/\\\/___
    _\/\\\/////////____\/\\\__\///\\\/___\/\\\________/\\\//_____
     _\/\\\_____________\/\\\____\///_____\/\\\_____/\\\//________
      _\/\\\_____________\/\\\_____________\/\\\___/\\\/___________
       _\/\\\_____________\/\\\_____________\/\\\__/\\\\\\\\\\\\\\\_
        _\///______________\///______________\///__\///////////////__


                       Getting started

                        Documentation
                        http://pm2.io/

                      Start PM2 at boot
                        $ pm2 startup

                     Daemonize Application
                       $ pm2 start <app>

                     Monitoring/APM solution
                    https://app.keymetrics.io/

                        -------------

[PM2] Spawning PM2 daemon with pm2_home=/root/.pm2
[PM2] PM2 Successfully daemonized
2.4.6
/ # pm2 -version
2.4.6
/ # 
```