### PR TITLE
 priority が低い TunerDevice を優先して奪還するよう修正

### DIFF
--- a/src/Mirakurun/Tuner.ts
+++ b/src/Mirakurun/Tuner.ts
@@ -376,6 +376,10 @@ export default class Tuner {
 
                 // 4. takeover existing
                 if (device === null) {
+                    devices.sort((t1, t2) => {
+                        return t1.getPriority() - t2.getPriority();
+                    });
+
                     for (let i = 0; i < length; i++) {
                         if (devices[i].isUsing === true && devices[i].getPriority() < user.priority) {
                             device = devices[i];


### PR DESCRIPTION
TunerDevice の priority が低い順から奪還するように修正しました。