### PR TITLE
fix db path for linux

### DIFF
--- a/doc/Platforms.md
+++ b/doc/Platforms.md
@@ -47,7 +47,7 @@ sudo npm uninstall mirakurun -g --unsafe
   * `server.yml`
   * `tuners.yml`
   * `channels.yml`
-* `/usr/local/db/mirakurun/` - databases
+* `/usr/local/var/db/mirakurun/` - databases
   * `services.json`
   * `programs.json`
 * `/usr/local/var/log/mirakurun.stdout.log` - normal log


### PR DESCRIPTION
ドキュメント上では `/usr/local/db/mirakurun/` がデータベースファイルのパスとなっていましたが、 `/usr/local/var/db/mirakurun/` が正しそうなので修正しました

https://github.com/Chinachu/Mirakurun/blob/4f7f9eb43dcf89aeb6261dcd6b47eb355b6c3295/bin/postinstall.js#L46

