### PR TITLE
fix garbled epg(extended event decoding).

### DIFF
--- a/src/Mirakurun/epg.ts
+++ b/src/Mirakurun/epg.ts
@@ -298,13 +298,15 @@ class EPG extends stream.Writable {
                                                 : new TsChar(desc.item_description_char).decode();
                                     current = key;
 
-                                    const char = new TsChar(desc.item_char).decode();
                                     if (extended[key] === undefined) {
-                                        extended[key] = char;
+                                        extended[key] = new Buffer(desc.item_char);
                                     } else {
-                                        extended[key] += char;
+                                        extended[key] = Buffer.concat([extended[key], desc.item_char]);
                                     }
                                 }
+                            }
+                            for (const key of Object.keys(extended)) {
+                                extended[key] = new TsChar(extended[key]).decode();
                             }
 
                             state.program.update({


### PR DESCRIPTION
[Issue #26 EPGデータの文字化け](https://github.com/Chinachu/Mirakurun/issues/26) の原因と思われる不具合修正です。

- extended_event_descriptor の処理として、このような方法が適切であるかは自信はありません。
    - 直近1週間程度実行した限り、文字化けは発生していません。
- JavaScrpt(TypeScript) に関しては素人です…。もっとよい修正方法があればご指摘ください。

ご査収の程、よろしくお願いいたします。
(すみません、寝ぼけて変な文章でしたので一部修正しました…)