### PR TITLE
fix EPIPE error occurred by decoder.kill

### DIFF
--- a/src/Mirakurun/Tuner.ts
+++ b/src/Mirakurun/Tuner.ts
@@ -418,7 +418,8 @@ export default class Tuner {
                                     tsFilter.emit("close");
                                     --status.streamCount.decoder;
                                 });
-                                tsFilter.once("close", () => decoder.kill("SIGKILL"));
+                                decoder.stdin.once("finish", () => decoder.kill("SIGKILL"));
+                                tsFilter.once("close", () => decoder.stdin.end());
                                 tsFilter.pipe(decoder.stdin);
                                 resolve(decoder.stdout);
                             }


### PR DESCRIPTION
**Environments**
- os: ubuntu 18.04
- node: v10.14.1
- mirakurun: 2.8.4

Streaming with the tuner which has the option "decoder" will cause EPIPE error and make the system crash after the stream stopped.