### PR TITLE
fix duplicate function call of _kill()

### DIFF
--- a/src/Mirakurun/TunerDevice.ts
+++ b/src/Mirakurun/TunerDevice.ts
@@ -382,6 +382,9 @@ export default class TunerDevice extends events.EventEmitter {
 
         if (!this._process || !this._process.pid) {
             throw new Error(util.format("TunerDevice#%d has not process", this._index));
+        } else if (this._closing) {
+            log.debug("TunerDevice#%d return because it is closing", this._index);
+            return;
         }
 
         this._isAvailable = false;


### PR DESCRIPTION
Environments
- os: ubuntu 18.04
- node: v10.14.1
- mirakurun: 2.8.4

When the record process which tuner has the option "dvbDevicePath" was killed,  the code
https://github.com/Chinachu/Mirakurun/blob/ed205a71adb1486e9f0a634dccc7b234a9890206/src/Mirakurun/TunerDevice.ts#L306
still be called if the code
https://github.com/Chinachu/Mirakurun/blob/ed205a71adb1486e9f0a634dccc7b234a9890206/src/Mirakurun/TunerDevice.ts#L317
execute later than cat.close()