### PR TITLE
PAT CRC 比較処理の修正

### DIFF
--- a/src/Mirakurun/TSFilter.ts
+++ b/src/Mirakurun/TSFilter.ts
@@ -299,7 +299,7 @@ export default class TSFilter extends stream.Duplex {
 
         // parse
         if (pid === 0 && this._patCRC.compare(packet.slice(packet[7] + 4, packet[7] + 8))) {
-            this._patCRC = packet.slice(packet[7] + 4, packet[7] + 8);
+            this._patCRC = Buffer.from(packet.slice(packet[7] + 4, packet[7] + 8));
             this._parses.push(packet);
         } else if (
             ((pid === 0x12 || pid === 0x29) && (this._parseEIT === true || this._provideEventId !== null)) ||


### PR DESCRIPTION
#51 の動作確認中に気になった動作の修正です。

PAT の CRC が不自然に変化してしまい、PAT のイベントが異常な頻度で発生し続けることがありました。

- 特に、サービスを制限している場合に顕著
- 前回比較時に `_patCRC` を保存した後、 0xFFFFFFFF となっていることが多い
  - サービス制限による PAT 書き換えで埋めた 0xFF ？
  - `Buffer.slice` で参照していたメモリ領域が上書きされた影響？

試しに `_patCRC` に値をコピーするように修正したところ、期待通りの動作をしているように見えます。
問題ないかご確認いただけますでしょうか。