### PR TITLE
change the default value of maxBufferBytesBeforeReady from 3MB to 8MB

### DIFF
--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -20,7 +20,7 @@ port: 40772 # integer or ~ (null)
 disableIPv6: false # boolean
 highWaterMark: 25165824 # integer (bytes)
 overflowTimeLimit: 30000 # integer (ms)
-maxBufferBytesBeforeReady: 3145728 # integer (bytes)
+maxBufferBytesBeforeReady: 8388608 # integer (bytes)
 eventEndTimeout: 1000 # integer (ms)
 programGCInterval: 900000 # integer (ms)
 epgGatheringInterval: 900000 # integer (ms)

--- a/src/Mirakurun/TSFilter.ts
+++ b/src/Mirakurun/TSFilter.ts
@@ -109,7 +109,7 @@ export default class TSFilter extends stream.Duplex {
     private _overflowTimeLimit: number = _.config.server.overflowTimeLimit || 1000 * 30;
     /** Number divisible by a multiple of 188 */
     private _maxBufferBytesBeforeReady: number = (() => {
-        let bytes = _.config.server.maxBufferBytesBeforeReady || 1024 * 1024 * 3;
+        let bytes = _.config.server.maxBufferBytesBeforeReady || 1024 * 1024 * 8;
         bytes = bytes - bytes % PACKET_SIZE;
         return bytes;
     })();


### PR DESCRIPTION
`maxBufferBytesBeforeReady`のデフォルト値を3MBから8MBに変更しました．BS録画で始めが欠けてしまう問題が改善すると思われます．

8MBでも欠けてしまう場合は，`server.yml`でより大きな値を`maxBufferBytesBeforeReady`に設定すれば回避可能です．
