### PR TITLE
`/config/channels/scan` エンドポイントにBS/CSチャンネルスキャン機能を追加する

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -49,6 +49,8 @@ export interface Channel {
 
 export type ChannelType = "GR" | "BS" | "CS" | "SKY";
 
+export type ChannelRegisterMode = "Channel" | "Service";
+
 export interface Service {
     id: ServiceItemId;
     serviceId: ServiceId;

--- a/src/Mirakurun/api/config/channels/scan.ts
+++ b/src/Mirakurun/api/config/channels/scan.ts
@@ -61,7 +61,7 @@ function range(start: number, end: number): string[] {
     return Array.from({length: (end - start + 1)}, (v, index) => (index + start).toString(10));
 }
 
-function generateScanConfig(option: ChannelScanOption): ScanConfig {
+export function generateScanConfig(option: ChannelScanOption): ScanConfig {
     switch (option.type) {
         case common.ChannelTypes.GR:
             option.startCh = option.startCh === undefined ? 13 : option.startCh;
@@ -108,7 +108,7 @@ function generateScanConfig(option: ChannelScanOption): ScanConfig {
     }
 }
 
-function generateChannelItemForService(type: common.ChannelType, channel: string, service: db.Service, registerOnDisabled: boolean): config.Channel {
+export function generateChannelItemForService(type: common.ChannelType, channel: string, service: db.Service, registerOnDisabled: boolean): config.Channel {
 
     let name = service.name;
     name = name.trim();
@@ -125,7 +125,7 @@ function generateChannelItemForService(type: common.ChannelType, channel: string
     };
 }
 
-function generateChannelItemForChannel(type: common.ChannelType, channel: string, services: db.Service[], registerOnDisabled: boolean): config.Channel {
+export function generateChannelItemForChannel(type: common.ChannelType, channel: string, services: db.Service[], registerOnDisabled: boolean): config.Channel {
 
     const baseName = services[0].name;
     let matchIndex = baseName.length;
@@ -163,7 +163,7 @@ function generateChannelItemForChannel(type: common.ChannelType, channel: string
     };
 }
 
-function generateChannelItems(registerMode: RegisterMode, type: common.ChannelType, channel: string, services: db.Service[], registerOnDisabled: boolean): config.Channel[] {
+export function generateChannelItems(registerMode: RegisterMode, type: common.ChannelType, channel: string, services: db.Service[], registerOnDisabled: boolean): config.Channel[] {
 
     if (registerMode === RegisterMode.Service) {
         const channelItems: config.Channel[] = [];

--- a/src/Mirakurun/api/config/channels/scan.ts
+++ b/src/Mirakurun/api/config/channels/scan.ts
@@ -130,6 +130,10 @@ function generateChannelItemForChannel(type: common.ChannelType, channel: string
     for (const service of services) {
         for (let i = 1; i < name.length && i < service.name.length; i++) {
             if (name[i] !== service.name[i]) {
+                // If the first letter is different, the service does not perform summarization.
+                if (i === 1) {
+                    break;
+                }
                 name = name.slice(0, i);
                 break;
             }
@@ -137,7 +141,7 @@ function generateChannelItemForChannel(type: common.ChannelType, channel: string
     }
     name = name.trim();
     if (name.length === 0) {
-        name = services[0].name || `${type}${channel}`;
+        name = `${type}${channel}`;
     }
 
     return {

--- a/src/Mirakurun/api/config/channels/scan.ts
+++ b/src/Mirakurun/api/config/channels/scan.ts
@@ -47,7 +47,7 @@ function generateScanConfig(type: string, startCh?: number, endCh?: number, star
             startCh = startCh === undefined ? 13 : startCh;
             endCh = endCh === undefined ? 62 : endCh;
             return {
-                channels: range(startCh, endCh).map((v) => v.toString(10)),
+                channels: range(startCh, endCh).map<string>((ch) => ch.toString(10)),
                 isRegisterEachService: (isRegisterEachService === undefined ? false : isRegisterEachService)
             };
         case common.ChannelTypes.BS:
@@ -57,10 +57,10 @@ function generateScanConfig(type: string, startCh?: number, endCh?: number, star
                 startSubch = startSubch === undefined ? 0 : startSubch;
                 endSubch = endSubch === undefined ? 2 : endSubch;
 
-                const channels = [];
+                const channels = new Array<string>();
                 for (const ch of range(startCh, endCh)) {
                     for (const sCh of range(startSubch, endSubch)) {
-                        channels.push(`BS${("00" + ch).slice(-2)}_${sCh}`);
+                        channels.push(`BS${ch.toString().padStart(2, "0")}_${sCh}`);
                     }
                 }
                 return {
@@ -71,14 +71,14 @@ function generateScanConfig(type: string, startCh?: number, endCh?: number, star
             startCh = startCh === undefined ? 101 : startCh;
             endCh = endCh === undefined ? 256 : endCh;
             return {
-                channels: range(startCh, endCh).map((v) => v.toString(10)),
+                channels: range(startCh, endCh).map<string>((ch) => ch.toString(10)),
                 isRegisterEachService: (isRegisterEachService === undefined ? true : isRegisterEachService)
             };
         case common.ChannelTypes.CS:
             startCh = startCh === undefined ? 2 : startCh;
             endCh = endCh === undefined ? 24 : endCh;
             return {
-                channels: range(startCh, endCh).map((v) => `CS${v.toString(10)}`),
+                channels: range(startCh, endCh).map<string>((ch) => `CS${ch}`),
                 isRegisterEachService: (isRegisterEachService === undefined ? true : isRegisterEachService)
             };
     }

--- a/src/Mirakurun/api/config/channels/scan.ts
+++ b/src/Mirakurun/api/config/channels/scan.ts
@@ -39,7 +39,9 @@ interface ScanConfig {
     readonly isRegisterEachService: boolean;
 }
 
-const range = (start, end) => Array.from({length: (end - start + 1)}, (v, index) => index + start);
+function range(start: number, end: number): string[] {
+    return Array.from({length: (end - start + 1)}, (v, index) => (index + start).toString(10));
+}
 
 function generateScanConfig(type: string, startCh?: number, endCh?: number, startSubch?: number, endSubch?: number, isBsSubchStyle?: boolean, isRegisterEachService?: boolean): ScanConfig {
     switch (type) {
@@ -47,7 +49,7 @@ function generateScanConfig(type: string, startCh?: number, endCh?: number, star
             startCh = startCh === undefined ? 13 : startCh;
             endCh = endCh === undefined ? 62 : endCh;
             return {
-                channels: range(startCh, endCh).map<string>((ch) => ch.toString(10)),
+                channels: range(startCh, endCh).map((ch) => ch),
                 isRegisterEachService: (isRegisterEachService === undefined ? false : isRegisterEachService)
             };
         case common.ChannelTypes.BS:
@@ -57,7 +59,7 @@ function generateScanConfig(type: string, startCh?: number, endCh?: number, star
                 startSubch = startSubch === undefined ? 0 : startSubch;
                 endSubch = endSubch === undefined ? 2 : endSubch;
 
-                const channels = new Array<string>();
+                const channels: string[] = [];
                 for (const ch of range(startCh, endCh)) {
                     for (const sCh of range(startSubch, endSubch)) {
                         channels.push(`BS${ch.toString().padStart(2, "0")}_${sCh}`);
@@ -71,14 +73,14 @@ function generateScanConfig(type: string, startCh?: number, endCh?: number, star
             startCh = startCh === undefined ? 101 : startCh;
             endCh = endCh === undefined ? 256 : endCh;
             return {
-                channels: range(startCh, endCh).map<string>((ch) => ch.toString(10)),
+                channels: range(startCh, endCh).map((ch) => ch),
                 isRegisterEachService: (isRegisterEachService === undefined ? true : isRegisterEachService)
             };
         case common.ChannelTypes.CS:
             startCh = startCh === undefined ? 2 : startCh;
             endCh = endCh === undefined ? 24 : endCh;
             return {
-                channels: range(startCh, endCh).map<string>((ch) => `CS${ch}`),
+                channels: range(startCh, endCh).map((ch) => `CS${ch}`),
                 isRegisterEachService: (isRegisterEachService === undefined ? true : isRegisterEachService)
             };
     }

--- a/src/Mirakurun/api/config/channels/scan.ts
+++ b/src/Mirakurun/api/config/channels/scan.ts
@@ -126,19 +126,29 @@ function generateChannelItemForService(type: common.ChannelType, channel: string
 
 function generateChannelItemForChannel(type: common.ChannelType, channel: string, services: db.Service[], registerOnDisabled: boolean): config.Channel {
 
-    let name = services[0].name;
-    for (const service of services) {
-        for (let i = 1; i < name.length && i < service.name.length; i++) {
-            if (name[i] !== service.name[i]) {
-                // If the first letter is different, the service does not perform summarization.
-                if (i === 1) {
+    const baseName = services[0].name;
+    let matchIndex = baseName.length;
+
+    for (let servicesIndex = 1; servicesIndex < services.length; servicesIndex++) {
+        const service = services[servicesIndex];
+        for (let nameIndex = 0; nameIndex < baseName.length && nameIndex < service.name.length; nameIndex++) {
+            if (baseName[nameIndex] !== service.name[nameIndex]) {
+                if (nameIndex === 0) {
                     break;
                 }
-                name = name.slice(0, i);
+                if (nameIndex < matchIndex) {
+                    matchIndex = nameIndex;
+                }
+                break;
+            }
+            if (nameIndex + 1 >= service.name.length && service.name.length < matchIndex) {
+                matchIndex = service.name.length;
                 break;
             }
         }
     }
+
+    let name = baseName.slice(0, matchIndex);
     name = name.trim();
     if (name.length === 0) {
         name = `${type}${channel}`;

--- a/src/Mirakurun/api/config/channels/scan.ts
+++ b/src/Mirakurun/api/config/channels/scan.ts
@@ -217,7 +217,7 @@ export const put: Operation = async (req, res) => {
             continue;
         }
 
-        const channelItems = generateChannelItems(type, channel, services, scanConfig.registerMode, registerOnDisabled);
+        const channelItems = generateChannelItems(type, channel, services, scanConfig.registerMode, scanConfig.registerOnDisabled);
 
         for (const channelItem of channelItems) {
             result.push(channelItem);

--- a/src/client.ts
+++ b/src/client.ts
@@ -77,8 +77,14 @@ export interface ServicesQuery {
 
 export interface ChannelScanOption {
     type?: apid.ChannelType;
-    min?: number;
-    max?: number;
+    minCh?: number;
+    maxCh?: number;
+    minSubCh?: number;
+    maxSubCh?: number;
+    useSubCh?: boolean;
+    registerMode?: apid.ChannelRegisterMode;
+    registerOnDisabled?: boolean;
+    refresh?: boolean;
 }
 
 export default class Client {

--- a/test/scan.spec.js
+++ b/test/scan.spec.js
@@ -1,0 +1,1675 @@
+var assert = require('assert');
+
+const scan = require("../lib/Mirakurun/api/config/channels/scan");
+
+describe("Mirakurun/api/config/channel/scan : generateScanConfig", () => {
+
+    it("GR: Type only", () => {
+        const config = scan.generateScanConfig({
+            type: "GR"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: startCh only", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            startCh: 61
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: endCh only", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            endCh: 14
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: startCh and endCh", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            startCh: 10,
+            endCh: 15
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["10", "11", "12", "13", "14", "15"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: subCh is not use", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: useSubCh = false", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            useSubCh: false
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: useSubCh = false and subCh", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            useSubCh: false,
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: useSubCh = true", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            useSubCh: true
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: useSubCh = true and subCh", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            useSubCh: true,
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: registerMode = Channel", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            registerMode: "Channel"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: registerMode = Service", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            registerMode: "Service"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Service",
+            registerOnDisabled: false
+        });
+    });
+
+    it("GR: registerOnDisabled = true", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            registerOnDisabled: true
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: true
+        });
+    });
+
+    it("GR: registerOnDisabled = false", () => {
+        const config = scan.generateScanConfig({
+            type: "GR",
+            registerOnDisabled: false
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62"],
+            registerMode: "Channel",
+            registerOnDisabled: false
+        });
+    });
+
+
+
+
+
+    it("BS: Type only", () => {
+        const config = scan.generateScanConfig({
+            type: "BS"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: startCh only", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            startCh: 255
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: endCh only", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            endCh: 102
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: startCh and endCh", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            startCh: 10,
+            endCh: 15
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["10", "11", "12", "13", "14", "15"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: subCh is not use", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: useSubCh = false", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            useSubCh: false
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: useSubCh = false and subCh", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            useSubCh: false,
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: useSubCh = true", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            useSubCh: true
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["BS01_0", "BS01_1", "BS01_2", "BS02_0", "BS02_1", "BS02_2", "BS03_0", "BS03_1", "BS03_2", "BS04_0", "BS04_1", "BS04_2", "BS05_0", "BS05_1", "BS05_2", "BS06_0", "BS06_1", "BS06_2", "BS07_0", "BS07_1", "BS07_2", "BS08_0", "BS08_1", "BS08_2", "BS09_0", "BS09_1", "BS09_2", "BS10_0", "BS10_1", "BS10_2", "BS11_0", "BS11_1", "BS11_2", "BS12_0", "BS12_1", "BS12_2", "BS13_0", "BS13_1", "BS13_2", "BS14_0", "BS14_1", "BS14_2", "BS15_0", "BS15_1", "BS15_2", "BS16_0", "BS16_1", "BS16_2", "BS17_0", "BS17_1", "BS17_2", "BS18_0", "BS18_1", "BS18_2", "BS19_0", "BS19_1", "BS19_2", "BS20_0", "BS20_1", "BS20_2", "BS21_0", "BS21_1", "BS21_2", "BS22_0", "BS22_1", "BS22_2", "BS23_0", "BS23_1", "BS23_2"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: useSubCh = true and subCh", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            useSubCh: true,
+            startSubCh: 5,
+            endSubCh: 7
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["BS01_5", "BS01_6", "BS01_7", "BS02_5", "BS02_6", "BS02_7", "BS03_5", "BS03_6", "BS03_7", "BS04_5", "BS04_6", "BS04_7", "BS05_5", "BS05_6", "BS05_7", "BS06_5", "BS06_6", "BS06_7", "BS07_5", "BS07_6", "BS07_7", "BS08_5", "BS08_6", "BS08_7", "BS09_5", "BS09_6", "BS09_7", "BS10_5", "BS10_6", "BS10_7", "BS11_5", "BS11_6", "BS11_7", "BS12_5", "BS12_6", "BS12_7", "BS13_5", "BS13_6", "BS13_7", "BS14_5", "BS14_6", "BS14_7", "BS15_5", "BS15_6", "BS15_7", "BS16_5", "BS16_6", "BS16_7", "BS17_5", "BS17_6", "BS17_7", "BS18_5", "BS18_6", "BS18_7", "BS19_5", "BS19_6", "BS19_7", "BS20_5", "BS20_6", "BS20_7", "BS21_5", "BS21_6", "BS21_7", "BS22_5", "BS22_6", "BS22_7", "BS23_5", "BS23_6", "BS23_7"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: useSubCh = true and Ch and subCh", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            useSubCh: true,
+            startCh: 30,
+            endCh: 31,
+            startSubCh: 10,
+            endSubCh: 11
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["BS30_10", "BS30_11", "BS31_10", "BS31_11"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: registerMode = Channel", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            registerMode: "Channel"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Channel",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: registerMode = Service", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            registerMode: "Service"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: registerOnDisabled = true", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            registerOnDisabled: true
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("BS: registerOnDisabled = false", () => {
+        const config = scan.generateScanConfig({
+            type: "BS",
+            registerOnDisabled: false
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191", "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207", "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223", "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239", "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255", "256"],
+            registerMode: "Service",
+            registerOnDisabled: false
+        });
+    });
+
+
+
+
+
+    it("CS: Type only", () => {
+        const config = scan.generateScanConfig({
+            type: "CS"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: startCh only", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            startCh: 23
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: endCh only", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            endCh: 3
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: startCh and endCh", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            startCh: 10,
+            endCh: 15
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS10", "CS11", "CS12", "CS13", "CS14", "CS15"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: subCh is not use", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: useSubCh = false", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            useSubCh: false
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: useSubCh = false and subCh", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            useSubCh: false,
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: useSubCh = true", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            useSubCh: true
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: useSubCh = true and subCh", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            useSubCh: true,
+            startSubCh: 5,
+            endSubCh: 10
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: registerMode = Channel", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            registerMode: "Channel"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Channel",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: registerMode = Service", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            registerMode: "Service"
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: registerOnDisabled = true", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            registerOnDisabled: true
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: true
+        });
+    });
+
+    it("CS: registerOnDisabled = false", () => {
+        const config = scan.generateScanConfig({
+            type: "CS",
+            registerOnDisabled: false
+        });
+        assert.deepStrictEqual(config, {
+            channels: ["CS2", "CS3", "CS4", "CS5", "CS6", "CS7", "CS8", "CS9", "CS10", "CS11", "CS12", "CS13", "CS14", "CS15", "CS16", "CS17", "CS18", "CS19", "CS20", "CS21", "CS22", "CS23", "CS24"],
+            registerMode: "Service",
+            registerOnDisabled: false
+        });
+    });
+});
+
+describe("Mirakurun/api/config/channel/scan : generateChannelItemForService", () => {
+
+    it("GR Regular case", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: "XXXテレビ",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: service.name,
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("BS Regular case", () => {
+        const type = "BS";
+        const ch = "20";
+        const registerOnDisabled = false;
+        const service = {
+            name: "XXXテレビ",
+            serviceId: 10
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: service.name,
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("BS Regular case (Subchannel style)", () => {
+        const type = "BS";
+        const ch = "BS01_1";
+        const registerOnDisabled = false;
+        const service = {
+            name: "XXXテレビ",
+            serviceId: 10
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: service.name,
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("CS Regular case", () => {
+        const type = "CS";
+        const ch = "CS30";
+        const registerOnDisabled = false;
+        const service = {
+            name: "XXXテレビ",
+            serviceId: 999
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: service.name,
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : half-width whitespace (end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: "X　X テレビ ",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : half-width whitespace (start)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: " X　X テレビ",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : half-width whitespace (start and end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: " X　X テレビ ",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : full-width whitespace (end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: "X　X テレビ　",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : full-width whitespace (start)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: "　X　X テレビ",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : full-width whitespace (start and end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: "　X　X テレビ　",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : multiple whitespace (start and end) case.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: " 　X　X テレビ　 ",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name trim : multiple whitespace (start and end) case.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: "　 X　X テレビ 　",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name Empty", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const service = {
+            name: "",
+            serviceId: 1
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10:1",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+
+    it("Name Empty trim case", () => {
+        const type = "GR";
+        const ch = "999";
+        const registerOnDisabled = true;
+        const service = {
+            name: " 　",
+            serviceId: 10
+        };
+        const channelItem = scan.generateChannelItemForService(type, ch, service, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR999:10",
+            type: type,
+            channel: ch,
+            serviceId: service.serviceId,
+            isDisabled: registerOnDisabled
+        });
+    });
+});
+
+describe("Mirakurun/api/config/channel/scan : generateChannelItemForChannel (single service)", () => {
+
+    it("GR Regular case", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "XXXテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: services[0].name,
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("BS Regular case", () => {
+        const type = "BS";
+        const ch = "20";
+        const registerOnDisabled = false;
+        const services = [
+            { name: "XXXテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: services[0].name,
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("BS Regular case (Subchannel style)", () => {
+        const type = "BS";
+        const ch = "BS01_1";
+        const registerOnDisabled = false;
+        const services = [
+            { name: "XXXテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: services[0].name,
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("CS Regular case", () => {
+        const type = "CS";
+        const ch = "CS30";
+        const registerOnDisabled = false;
+        const services = [
+            { name: "XXXテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: services[0].name,
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : half-width whitespace (end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "X　X テレビ " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : half-width whitespace (start)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " X　X テレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : half-width whitespace (start and end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " X　X テレビ " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : full-width whitespace (end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "X　X テレビ　" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : full-width whitespace (start)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "　X　X テレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : full-width whitespace (start and end)", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "　X　X テレビ　" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : multiple whitespace (start and end) case.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " 　X　X テレビ　 " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name trim : multiple whitespace (start and end) case.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "　 X　X テレビ 　" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "X　X テレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Empty", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Empty trim case", () => {
+        const type = "GR";
+        const ch = "999";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " 　" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR999",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+});
+
+describe("Mirakurun/api/config/channel/scan : generateChannelItemForChannel (multiple service)", () => {
+
+    it("Name Summary regular case.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "xxxテレビ１" },
+            { name: "xxxテレビ２" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary regular case.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "xxxテレビ" },
+            { name: "xxxテレビ１" },
+            { name: "xxxテレビ２" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary regular case.3", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "xxxテレビ" },
+            { name: "xxxテレビ１" },
+            { name: "データ通信" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary regular case.4", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "xxxテレビ" },
+            { name: "xxxテレビ" },
+            { name: "xxxテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary regular case.5", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "xxxテレビ総合" },
+            { name: "xxxテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary regular case.6", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "aaaテレビ" },
+            { name: "bbbテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "aaaテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary and trim.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " xxxテレビ " },
+            { name: " xxxテレビ " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary and trim.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " xxxテレビ " },
+            { name: " xxxテレビ" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary and trim.3", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " xxxテレビ " },
+            { name: " xxxTV" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxx",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary and trim.4", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " xxxテレビ " },
+            { name: " aaaテレビ " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary and trim.5", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " xxxテレビ " },
+            { name: "xxxTV " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary and trim.6", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "xxxテレビ " },
+            { name: "xxxテレビ １" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary and trim.7", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "xxxテレビ １" },
+            { name: "xxxテレビ " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "xxxテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Full text match case.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "abcdefg" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Full text match case.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "abcdefgf" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Full text match case.3", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "xxxxx" },
+            { name: "abcdefg" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Full text match case.4", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "xxxxx" },
+            { name: "abcdefg" },
+            { name: "xxx" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Partial text match case.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "abcabc" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abc",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Partial text match case.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "xxxx" },
+            { name: "abcabc" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abc",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Partial text match case.3", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "xxxx" },
+            { name: "abcabc" },
+            { name: "yyy" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abc",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Not match case.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "xxxx" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Not match case.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "xabcdefg" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Not match case.3", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "yyy" },
+            { name: "xxx" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Not match case.4", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: "" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Not match case.5", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "abcdefg" },
+            { name: " " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "abcdefg",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Empty case.1", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "" },
+            { name: "abcdefg" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Empty case.2", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "" },
+            { name: "" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Empty case.3", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "" },
+            { name: " " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Empty case.4", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " " },
+            { name: "abcdefg" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Empty case.5", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " " },
+            { name: "" }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+
+    it("Name Summary : Empty case.6", () => {
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: " " },
+            { name: " " }
+        ];
+        const channelItem = scan.generateChannelItemForChannel(type, ch, services, registerOnDisabled);
+        assert.deepStrictEqual(channelItem, {
+            name: "GR10",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItem, false);
+    });
+});
+
+describe("Mirakurun/api/config/channel/scan : generateChannelItems", () => {
+
+    it("Service mode case.1", () => {
+        const mode = "Service";
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "XXXテレビ", serviceId: 1 }
+        ];
+        const channelItems = scan.generateChannelItems(mode, type, ch, services, registerOnDisabled);
+        assert.strictEqual(channelItems.length, services.length);
+        for (let i = 0; i < channelItems.length; i++) {
+            assert.deepStrictEqual(channelItems[i], {
+                name: services[i].name,
+                type: type,
+                channel: ch,
+                serviceId: services[i].serviceId,
+                isDisabled: registerOnDisabled
+            });
+        }
+    });
+
+    it("Service mode case.2 : multiple service", () => {
+        const mode = "Service";
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "XXXテレビ１", serviceId: 101 },
+            { name: "XXXテレビ２", serviceId: 102 }
+        ];
+        const channelItems = scan.generateChannelItems(mode, type, ch, services, registerOnDisabled);
+        assert.strictEqual(channelItems.length, services.length);
+        for (let i = 0; i < channelItems.length; i++) {
+            assert.deepStrictEqual(channelItems[i], {
+                name: services[i].name,
+                type: type,
+                channel: ch,
+                serviceId: services[i].serviceId,
+                isDisabled: registerOnDisabled
+            });
+        }
+    });
+
+    it("Channel mode case.1", () => {
+        const mode = "Channel";
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "XXXテレビ", serviceId: 1 }
+        ];
+        const channelItems = scan.generateChannelItems(mode, type, ch, services, registerOnDisabled);
+        assert.strictEqual(channelItems.length, 1);
+        assert.deepStrictEqual(channelItems[0], {
+            name: services[0].name,
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItems[0], false);
+    });
+
+    it("Channel mode case.2 : multiple service", () => {
+        const mode = "Channel";
+        const type = "GR";
+        const ch = "10";
+        const registerOnDisabled = true;
+        const services = [
+            { name: "XXXテレビ１", serviceId: 101 },
+            { name: "XXXテレビ２", serviceId: 102 }
+        ];
+        const channelItems = scan.generateChannelItems(mode, type, ch, services, registerOnDisabled);
+        assert.strictEqual(channelItems.length, 1);
+        assert.deepStrictEqual(channelItems[0], {
+            name: "XXXテレビ",
+            type: type,
+            channel: ch,
+            isDisabled: registerOnDisabled
+        });
+        assert.strictEqual("serviceId" in channelItems[0], false);
+    });
+});
+
+describe("Mirakurun/api/config/channel/scan : generateChannelItems Channel(and Other) mode", () => {
+});
+
+describe("Mirakurun/api/config/channel/scan : generateChannelItems Service mode - Multiple service", () => {
+
+});
+
+describe("Mirakurun/api/config/channel/scan : generateChannelItems Channel(and Other) mode with Takeover", () => {
+});

--- a/test/scan.spec.js
+++ b/test/scan.spec.js
@@ -165,10 +165,6 @@ describe("Mirakurun/api/config/channel/scan : generateScanConfig", () => {
         });
     });
 
-
-
-
-
     it("BS: Type only", () => {
         const config = scan.generateScanConfig({
             type: "BS"
@@ -345,10 +341,6 @@ describe("Mirakurun/api/config/channel/scan : generateScanConfig", () => {
             registerOnDisabled: false
         });
     });
-
-
-
-
 
     it("CS: Type only", () => {
         const config = scan.generateScanConfig({
@@ -1662,14 +1654,4 @@ describe("Mirakurun/api/config/channel/scan : generateChannelItems", () => {
         });
         assert.strictEqual("serviceId" in channelItems[0], false);
     });
-});
-
-describe("Mirakurun/api/config/channel/scan : generateChannelItems Channel(and Other) mode", () => {
-});
-
-describe("Mirakurun/api/config/channel/scan : generateChannelItems Service mode - Multiple service", () => {
-
-});
-
-describe("Mirakurun/api/config/channel/scan : generateChannelItems Channel(and Other) mode with Takeover", () => {
 });


### PR DESCRIPTION
このプルリクの目的は、 `/config/channels/scan` エンドポイントでBS/CSのチャンネルをスキャンできるように機能を拡張することです。SKYは対象外です。仕様はおおむねapiDocに書けていると思うのでそちらを参照してください。

BS/CSスキャンの追加以外に、GRスキャン時の動作が一部変わっています。

1. チャンネルにサービスが複数ある場合、すべてのサービスを登録するように変更
1. `serviceId` を登録するように変更
1. チャンネル名が空文字の場合、 `${type}${channel}:${service.serviceId}` で代替するように変更

GRの動作を変えることが目的ではなく、コードをシンプルに保つためGR/BS/CSの処理をできる限り統一したことによる影響です。

影響が大きそうな1に関してですが、現行コードで1件目のサービスのみを登録している意図がいまいち理解できませんでした。GRでも1件目のサービスと異なる番組を放送するチャンネルをちらほら見かける(ＮＨＫ総合２とか)ので、現在の動作はあまりよくないかなと思い変更しました。2, 3に関してはサービスを扱うようになったので必然的にという感じです。

気がかりなこととしては、recept1の仕様？に合わせるためにBSのチャンネル文字列(例: BS01_1)を生成する処理が必要になり、これに関連して無駄に複雑になっている感があること。問題なければこのままでいきたいと思っています。

本プロジェクトにコミットするのは初なので、初歩的なところやそもそもアプローチおかしいとかあっても優しく指摘してくれると嬉しいです。:wink: