### PR TITLE
Kodi 19のIPTV機能でチャンネル選択に時間がかかる問題を修正

### DIFF
--- a/src/Mirakurun/api/iptv/playlist.ts
+++ b/src/Mirakurun/api/iptv/playlist.ts
@@ -29,6 +29,7 @@ export const get: Operation = async (req, res) => {
             continue;
         }
 
+        m += `#KODIPROP:mimetype=video/mp2t\n`;
         m += `#EXTINF:-1 tvg-id="${service.id}"`;
         if (await Service.isLogoDataExists(service.networkId, service.logoId)) {
             m += ` tvg-logo="${apiRoot}/services/${service.id}/logo"`;


### PR DESCRIPTION
Kodi 19.1のPVR IPTV Simple Clientではチャンネル選択・切り替えに数十秒ほど時間がかかる問題が発生していたので、M3UプレイリストにKodi用の属性を追加して解消しました。

動作確認済み環境（Kodi 19.1以外はデグレしていないことの確認）
Kodi 19.1 - Chromecast with Google TV
Kodi 18.9 - Fire TV Stick
Cloud Stream IPTV Player - iPhone 8 Plus

ソースコード上の他の箇所では `video/MP2T` という大文字での指定でしたが、 `KODIPROP:mimetype` では小文字でしか再生できなかったため、ここだけ小文字にしています。
また念の為、stream配信時の `Content-Type: video/MP2T` を小文字にすることも試してみましたが、解消されませんでした。

Kodi側のアップデートで解消されるかもしれず、Kodi用の属性をプレイリストに持つことに抵抗はありましたが、現状一番シンプルな修正かと考えています。