### PR TITLE
無効化されたチューナーが存在する際に WebUI のインデックスがおかしくなる問題を修正

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -185,7 +185,7 @@ rpc.methods.set("events", async (socket, { array }: NotifyParams<EventMessage>) 
         } else if (event.resource === "tuner") {
             const tuner: TunerDevice = event.data;
 
-            uiState.tuners[tuner.index] = tuner;
+            uiState.tuners[uiState.tuners.findIndex(value => value.index === tuner.index)] = tuner;
             uiStateEvents.emit("update:tuners");
         }
     }


### PR DESCRIPTION
恐らくこちらと同じ問題を修正します。 https://discord.com/channels/598783457165836309/615113079658774529/887018855317270579

isDisabled が true になっているチューナーを有効なチューナーよりも先に設定し、チューナー情報が更新されると再現できるかと思います。