### PR TITLE
fix: 超高精細度4K専用TVサービスをデジタルTVサービスと同等として扱う

### DIFF
--- a/src/Mirakurun/api/config/channels/scan.ts
+++ b/src/Mirakurun/api/config/channels/scan.ts
@@ -279,7 +279,7 @@ export const put: Operation = async (req, res) => {
             continue;
         }
 
-        services = services.filter(service => service.type === 1);
+        services = services.filter(service => service.type === 1 || service.type === 173);
         res.write(`-> ${services.length} services found.\n`);
 
         if (services.length === 0) {

--- a/src/Mirakurun/api/iptv/lineup.json.ts
+++ b/src/Mirakurun/api/iptv/lineup.json.ts
@@ -35,7 +35,7 @@ export const get: Operation = (req, res) => {
 
     const countMap = new Map<number, number>();
     for (const service of services) {
-        if (service.type !== 1) {
+        if (service.type !== 1 && service.type !== 173) {
             continue;
         }
 

--- a/src/Mirakurun/api/iptv/playlist.ts
+++ b/src/Mirakurun/api/iptv/playlist.ts
@@ -26,7 +26,7 @@ export const get: Operation = async (req, res) => {
 
     let m = `#EXTM3U url-tvg="${apiRoot}/iptv/xmltv"\n`;
     for (const service of services) {
-        if (service.type !== 1) {
+        if (service.type !== 1 && service.type !== 173) {
             continue;
         }
 

--- a/src/Mirakurun/api/iptv/xmltv.ts
+++ b/src/Mirakurun/api/iptv/xmltv.ts
@@ -248,7 +248,7 @@ export const get: Operation = async (req, res) => {
 
     const countMap = new Map<number, number>();
     for (const service of services) {
-        if (service.type !== 1) {
+        if (service.type !== 1 && service.type !== 173) {
             continue;
         }
 

--- a/src/ui/components/StatusView.tsx
+++ b/src/ui/components/StatusView.tsx
@@ -109,7 +109,7 @@ const StatusView: React.FC<{ uiState: UIState, uiStateEvents: EventEmitter }> = 
     const serviceList: JSX.Element[] = [];
     for (let i = 0; i < services.length; i++) {
         const service = services[i];
-        if (service.type !== 1) {
+        if (service.type !== 1 && service.type !== 173) {
             continue;
         }
         const tooltipId = `service-list-item#${i}-tooltip`;


### PR DESCRIPTION
ケーブルテレビ向け4K専門チャンネルの [ケーブル4K](https://www.cable4k.jp/) を Mirakurun に追加したところ、チャンネルがダッシュボードのサービス一覧や IPTV 向けプレイリストに出てきませんでした(ケーブル4Kはノンスクランブル放送です)。
`/api/services` では表示されており、VLC で直接サービスのストリームを開くことはできたのでコードを確認した所、サービスのタイプが `1` の物のみ表示しているようでした。
念の為にケーブル4Kのサービスタイプを確認したところ、`173` となっており、これは `超高精細度4K専用TVサービス` を意味していました( https://github.com/DBCTRADO/LibISDB/blob/e8f2bedcd3b5a860085623d6813387fccdac91c2/LibISDB/LibISDBConsts.hpp#L138 にて定義されています)。
各所のサービスタイプの判定式で `173` も `1` と同等に扱うようにコードを変更したところ、正しく表示されるようになりました。

他のケーブルテレビ局では別なサービスタイプの可能性もあるとは思いますが、少なくともイッツコム(東京)ではケーブル4Kのサービスタイプは `173` になっているので、`173`  については `1` と同等として扱うのが適当かと思います。

なお手元で受信できる他の4K放送(J SPORTS 4K など)のサービスタイプは `1` でした。
