### PR TITLE
番組がリスケジュールされた際に、必要な番組まで削除される不具合を修正

### DIFF
--- a/src/Mirakurun/EPG.ts
+++ b/src/Mirakurun/EPG.ts
@@ -180,7 +180,7 @@ export default class EPG {
                         startAt: getTimeFromMJD(e.start_time),
                         duration: UNKNOWN_DURATION.compare(e.duration) === 0 ? 1 : getTimeFromBCD24(e.duration),
                         isFree: e.free_CA_mode === 0,
-                        _pf: isPF || undefined,     // for compatibility
+                        _pf: isPF || undefined, // for compatibility
                         _isPresent: isP || undefined,
                         _isFollowing: isF || undefined
                     };
@@ -231,7 +231,7 @@ export default class EPG {
                             startAt: getTimeFromMJD(e.start_time),
                             duration: UNKNOWN_DURATION.compare(e.duration) === 0 ? 1 : getTimeFromBCD24(e.duration),
                             isFree: e.free_CA_mode === 0,
-                            _pf: isPF || undefined,     // for compatibility
+                            _pf: isPF || undefined, // for compatibility
                             _isPresent: isP || undefined,
                             _isFollowing: isF || undefined
                         });

--- a/src/Mirakurun/EPG.ts
+++ b/src/Mirakurun/EPG.ts
@@ -128,7 +128,7 @@ interface EventState {
     };
 
     present?: true;
-    follow?: true;
+    following?: true;
 }
 
 // forked from rndomhack/node-aribts/blob/1e7ef94bba3d6ac26aec764bf24dde2c2852bfcb/lib/epg.js
@@ -215,7 +215,7 @@ export default class EPG {
                         _groups: []
                     },
                     present: isP || undefined,
-                    follow: isF || undefined
+                    following: isF || undefined
                 };
 
                 state.version[eit.table_id] = eit.version_number;
@@ -223,7 +223,7 @@ export default class EPG {
             } else {
                 state = service[e.event_id];
 
-                if ((!state.present && isP) || (!state.follow && isF) || isOutOfDate(eit, state.version)) {
+                if ((!state.present && isP) || (!state.following && isF) || isOutOfDate(eit, state.version)) {
                     state.version[eit.table_id] = eit.version_number;
 
                     if (UNKNOWN_START_TIME.compare(e.start_time) !== 0) {
@@ -238,7 +238,7 @@ export default class EPG {
                     }
 
                     state.present = isP || undefined;
-                    state.follow = isF || undefined;
+                    state.following = isF || undefined;
                 }
             }
 

--- a/src/Mirakurun/EPG.ts
+++ b/src/Mirakurun/EPG.ts
@@ -128,6 +128,7 @@ interface EventState {
     };
 
     present?: true;
+    follow?: true;
 }
 
 // forked from rndomhack/node-aribts/blob/1e7ef94bba3d6ac26aec764bf24dde2c2852bfcb/lib/epg.js
@@ -148,6 +149,7 @@ export default class EPG {
         }
 
         const isP = isPF && eit.section_number === 0;
+        const isF = isPF && eit.section_number === 1;
 
         const networkId = eit.original_network_id;
 
@@ -178,7 +180,9 @@ export default class EPG {
                         startAt: getTimeFromMJD(e.start_time),
                         duration: UNKNOWN_DURATION.compare(e.duration) === 0 ? 1 : getTimeFromBCD24(e.duration),
                         isFree: e.free_CA_mode === 0,
-                        _pf: isPF || undefined
+                        _pf: isPF || undefined,     // for compatibility
+                        _isPresent: isP || undefined,
+                        _isFollowing: isF || undefined
                     };
                     _.program.add(programItem);
                 }
@@ -210,19 +214,16 @@ export default class EPG {
                         version: {},
                         _groups: []
                     },
-
-                    present: isP || undefined
+                    present: isP || undefined,
+                    follow: isF || undefined
                 };
 
+                state.version[eit.table_id] = eit.version_number;
                 service[e.event_id] = state;
             } else {
                 state = service[e.event_id];
 
-                if (!state.present && isP) {
-                    state.present = true;
-                }
-
-                if ((!state.present || (state.present && isP)) && isOutOfDate(eit, state.version)) {
+                if ((!state.present && isP) || (!state.follow && isF) || isOutOfDate(eit, state.version)) {
                     state.version[eit.table_id] = eit.version_number;
 
                     if (UNKNOWN_START_TIME.compare(e.start_time) !== 0) {
@@ -230,9 +231,14 @@ export default class EPG {
                             startAt: getTimeFromMJD(e.start_time),
                             duration: UNKNOWN_DURATION.compare(e.duration) === 0 ? 1 : getTimeFromBCD24(e.duration),
                             isFree: e.free_CA_mode === 0,
-                            _pf: isPF || undefined
+                            _pf: isPF || undefined,     // for compatibility
+                            _isPresent: isP || undefined,
+                            _isFollowing: isF || undefined
                         });
                     }
+
+                    state.present = isP || undefined;
+                    state.follow = isF || undefined;
                 }
             }
 

--- a/src/Mirakurun/Program.ts
+++ b/src/Mirakurun/Program.ts
@@ -83,7 +83,7 @@ export default class Program {
                 this.save();
 
                 log.debug(
-                    "ProgramItem#%d (networkId=%d, serviceId=%d, eventId=%d) has recoved from the logically-deleted store",
+                    "ProgramItem#%d (networkId=%d, serviceId=%d, eventId=%d) has recovered from the logically-deleted store",
                     item.id, item.networkId, item.serviceId, item.eventId
                 );
             }

--- a/src/Mirakurun/Program.ts
+++ b/src/Mirakurun/Program.ts
@@ -79,7 +79,7 @@ export default class Program {
             if (item) {
                 this._itemMap.set(item.id, item);
                 this._itemMapDeleted.delete(item.id);
-                this._emitPrograms.set(item, "update");
+                this._emitPrograms.set(item, "create");
                 this.save();
 
                 log.debug(

--- a/src/Mirakurun/Program.ts
+++ b/src/Mirakurun/Program.ts
@@ -28,6 +28,7 @@ export function getProgramItemId(networkId: number, serviceId: number, eventId: 
 export default class Program {
 
     private _itemMap = new Map<number, db.Program>();
+    private _itemMapDeleted = new Map<number, db.Program>();
     private _saveTimerId: NodeJS.Timer;
     private _emitTimerId: NodeJS.Timer;
     private _emitRunning = false;
@@ -50,6 +51,9 @@ export default class Program {
             return;
         }
 
+        // purge logically deleted item
+        this._itemMapDeleted.delete(item.id);
+
         if (firstAdd === false) {
             this._findAndRemoveConflicts(item);
         }
@@ -68,7 +72,22 @@ export default class Program {
     }
 
     set(id: number, props: Partial<db.Program>): void {
-        const item = this.get(id);
+        let item = this.get(id);
+        if (!item) {
+            // Recovers logically deleted item if that is exsts into the tempolally collection.
+            item = this._itemMapDeleted.get(id) || null;
+            if (item) {
+                this._itemMap.set(item.id, item);
+                this._itemMapDeleted.delete(item.id);
+                this._emitPrograms.set(item, "update");
+                this.save();
+
+                log.debug(
+                    "ProgramItem#%d (networkId=%d, serviceId=%d, eventId=%d) has recoved from the logically-deleted store",
+                    item.id, item.networkId, item.serviceId, item.eventId
+                );
+            }
+        }
         if (item && common.updateObject(item, props) === true) {
             if (props.startAt || props.duration) {
                 this._findAndRemoveConflicts(item);
@@ -78,14 +97,27 @@ export default class Program {
         }
     }
 
-    remove(id: number): void {
-        if (this._itemMap.delete(id)) {
-            this.save();
+    remove(id: number, logicallyDelete: boolean = false): void {
+        if (logicallyDelete) {
+            const item = this.get(id);
+            if (item) {
+                this._itemMapDeleted.set(item.id, item);
+                this._itemMap.delete(id);
+                this.save();
+            }
+        } else {
+            if (this._itemMap.delete(id)) {
+                this.save();
+            }
         }
     }
 
     exists(id: number): boolean {
         return this._itemMap.has(id);
+    }
+
+    isLogicallyDeleted(id: number): boolean {
+        return this._itemMapDeleted.has(id);
     }
 
     findByQuery(query: object): db.Program[] {
@@ -189,9 +221,9 @@ export default class Program {
                         (added.startAt <= item.startAt && item.startAt < addedEndAt) ||
                         (item.startAt <= added.startAt && added.startAt < itemEndAt)
                     ) &&
-                    (!item._pf || added._pf)
+                    (!(item._isPresent || item._isFollowing) || added._isPresent)
                 ) {
-                    this.remove(item.id);
+                    this.remove(item.id, true);
                     Event.emit("program", "remove", { id: item.id });
 
                     log.debug(
@@ -227,6 +259,7 @@ export default class Program {
 
         log.debug("saving programs...");
 
+        // TODO: Do we need to save/load logically deleted items?
         db.savePrograms(
             Array.from(this._itemMap.values()),
             _.configIntegrity.channels
@@ -251,6 +284,17 @@ export default class Program {
                 ) {
                     ++count;
                     this.remove(item.id);
+                }
+            }
+
+            // Perform GC for the logically-deleted store
+            for (const item of this._itemMapDeleted.values()) {
+                if (
+                    (item.duration === 1 ? longExp : shortExp) > (item.startAt + item.duration) ||
+                    maximum < item.startAt
+                ) {
+                    ++count;
+                    this._itemMapDeleted.delete(item.id);
                 }
             }
 

--- a/src/Mirakurun/db.ts
+++ b/src/Mirakurun/db.ts
@@ -64,7 +64,9 @@ export interface Program {
     relatedItems?: ProgramRelatedItem[];
 
     /** (internal) indicates EIT[p/f] received */
-    _pf?: true;
+    _pf?: true;     // for compatibility
+    _isPresent?: true;
+    _isFollowing?: true;
 }
 
 export interface ProgramGenre {

--- a/src/Mirakurun/db.ts
+++ b/src/Mirakurun/db.ts
@@ -64,7 +64,7 @@ export interface Program {
     relatedItems?: ProgramRelatedItem[];
 
     /** (internal) indicates EIT[p/f] received */
-    _pf?: true;     // for compatibility
+    _pf?: true; // for compatibility
     _isPresent?: true;
     _isFollowing?: true;
 }


### PR DESCRIPTION
## バグの内容
 番組スケジュールが変更になった際に放送時間の重なりをチェックして番組を削除しているが、必要な番組まで削除されてしまう
## バグの原因
例えば、スポーツ番組などで放送時間が延長された場合、後続番組との重なりは避けられないので、"Forrowing"の番組も含めて削除される場合がある
以降受信するEIT[p/f]やEIT[schedle]で番組情報が復活されることが望まれるが、重なりが生じて削除された番組はProgramクラスが保持している情報にすでに存在しないため、以下に示すコードの229行目の"set"が失敗する（例外としてはEIT[schedule]からEIT[p/f]へテープルが移行した番組はこの限りではない）
https://github.com/Chinachu/Mirakurun/blob/31b22cc83cb2166c117a2fba8f2499d467750dc8/src/Mirakurun/EPG.ts#L217-L236
また、Following番組の開始が早まった場合、EIT[p]よりもEIT[f]を先に受信してしまうと、Following番組でPresent番組が削除されてしまう
https://github.com/Chinachu/Mirakurun/blob/31b22cc83cb2166c117a2fba8f2499d467750dc8/src/Mirakurun/Program.ts#L187-L193
## 改善内容
- Programオブジェクトに"Present","Following"を識別できるプロパティを追加し、"Following"と"Present"を識別することで"Present"が削除されない様にする
- 番組の延長などにより一旦削除されても直後に受信するEITにより完全なプログラム情報を提供できるよう、削除した番組情報を一時保管するバッファを用意し、削除済みの番組に対して"add"が呼ばれないで再び"set"メソッドが呼ばれたら一時保管バッファに保管していた情報を戻して処理する
- 放送番組の変更（例えばスポーツ番組が中止になり、他の番組に差し替えなど）が発生じた際の削除では、一時保管バッファに溜まったままになるので、gcを実行するタイミングで一時保管バッファから削除する