### PR TITLE
Add head request for stream

### DIFF
--- a/src/Mirakurun/api/channels/{type}/{channel}/services/{id}/stream.ts
+++ b/src/Mirakurun/api/channels/{type}/{channel}/services/{id}/stream.ts
@@ -54,6 +54,22 @@ export const parameters = [
     }
 ];
 
+export const head: Operation = (req, res) => {
+
+    const channel = _.channel.get(req.params.type as ChannelType, req.params.channel);
+
+    if (channel === null) {
+        api.responseError(res, 404);
+        return;
+    }
+
+    const userId = (req.ip || "unix") + ":" + (req.socket.remotePort || Date.now());
+
+    res.setHeader("Content-Type", "video/MP2T");
+    res.setHeader("X-Mirakurun-Tuner-User-ID", userId);
+    res.status(200).end();
+};
+
 export const get: Operation = (req, res) => {
 
     const channel = _.channel.get(req.params.type as ChannelType, req.params.channel);
@@ -99,6 +115,31 @@ export const get: Operation = (req, res) => {
             res.status(200);
         })
         .catch((err) => api.responseStreamErrorHandler(res, err));
+};
+
+head.apiDoc = {
+    tags: ["channels", "services", "stream"],
+    operationId: "getServiceStreamByChannel",
+    produces: ["video/MP2T"],
+    responses: {
+        200: {
+            description: "OK",
+            headers: {
+                "X-Mirakurun-Tuner-User-ID": {
+                    type: "string"
+                }
+            }
+        },
+        404: {
+            description: "Not Found"
+        },
+        503: {
+            description: "Tuner Resource Unavailable"
+        },
+        default: {
+            description: "Unexpected Error"
+        }
+    }
 };
 
 get.apiDoc = {

--- a/src/Mirakurun/api/channels/{type}/{channel}/stream.ts
+++ b/src/Mirakurun/api/channels/{type}/{channel}/stream.ts
@@ -47,6 +47,22 @@ export const parameters = [
     }
 ];
 
+export const head: Operation = (req, res) => {
+
+    const channel = _.channel.get(req.params.type as ChannelType, req.params.channel);
+
+    if (channel === null) {
+        api.responseError(res, 404);
+        return;
+    }
+
+    const userId = (req.ip || "unix") + ":" + (req.socket.remotePort || Date.now());
+
+    res.setHeader("Content-Type", "video/MP2T");
+    res.setHeader("X-Mirakurun-Tuner-User-ID", userId);
+    res.status(200).end();
+};
+
 export const get: Operation = (req, res) => {
 
     const channel = _.channel.get(req.params.type as ChannelType, req.params.channel);
@@ -83,6 +99,31 @@ export const get: Operation = (req, res) => {
             res.status(200);
         })
         .catch((err) => api.responseStreamErrorHandler(res, err));
+};
+
+head.apiDoc = {
+    tags: ["channels", "stream"],
+    operationId: "getChannelStream",
+    produces: ["video/MP2T"],
+    responses: {
+        200: {
+            description: "OK",
+            headers: {
+                "X-Mirakurun-Tuner-User-ID": {
+                    type: "string"
+                }
+            }
+        },
+        404: {
+            description: "Not Found"
+        },
+        503: {
+            description: "Tuner Resource Unavailable"
+        },
+        default: {
+            description: "Unexpected Error"
+        }
+    }
 };
 
 get.apiDoc = {

--- a/src/Mirakurun/api/programs/{id}/stream.ts
+++ b/src/Mirakurun/api/programs/{id}/stream.ts
@@ -41,6 +41,22 @@ export const parameters = [
     }
 ];
 
+export const head: Operation = (req, res) => {
+
+    const program = _.program.get(req.params.id as any as number);
+
+    if (program === null) {
+        api.responseError(res, 404);
+        return;
+    }
+
+    const userId = (req.ip || "unix") + ":" + (req.socket.remotePort || Date.now());
+
+    res.setHeader("Content-Type", "video/MP2T");
+    res.setHeader("X-Mirakurun-Tuner-User-ID", userId);
+    res.status(200).end();
+};
+
 export const get: Operation = (req, res) => {
 
     const program = _.program.get(req.params.id as any as number);
@@ -79,6 +95,31 @@ export const get: Operation = (req, res) => {
             req.setTimeout(1000 * 60 * 10); // 10 minites
         })
         .catch((err) => api.responseStreamErrorHandler(res, err));
+};
+
+head.apiDoc = {
+    tags: ["programs", "stream"],
+    operationId: "getProgramStream",
+    produces: ["video/MP2T"],
+    responses: {
+        200: {
+            description: "OK",
+            headers: {
+                "X-Mirakurun-Tuner-User-ID": {
+                    type: "string"
+                }
+            }
+        },
+        404: {
+            description: "Not Found"
+        },
+        503: {
+            description: "Tuner Resource Unavailable"
+        },
+        default: {
+            description: "Unexpected Error"
+        }
+    }
 };
 
 get.apiDoc = {

--- a/src/Mirakurun/api/services/{id}/stream.ts
+++ b/src/Mirakurun/api/services/{id}/stream.ts
@@ -40,6 +40,22 @@ export const parameters = [
     }
 ];
 
+export const head: Operation = (req, res) => {
+
+    const service = _.service.get(req.params.id as any as number);
+
+    if (service === null || service === undefined) {
+        api.responseError(res, 404);
+        return;
+    }
+
+    const userId = (req.ip || "unix") + ":" + (req.socket.remotePort || Date.now());
+
+    res.setHeader("Content-Type", "video/MP2T");
+    res.setHeader("X-Mirakurun-Tuner-User-ID", userId);
+    res.status(200).end();
+};
+
 export const get: Operation = (req, res) => {
 
     const service = _.service.get(req.params.id as any as number);
@@ -76,6 +92,31 @@ export const get: Operation = (req, res) => {
             res.status(200);
         })
         .catch((err) => api.responseStreamErrorHandler(res, err));
+};
+
+head.apiDoc = {
+    tags: ["services", "stream"],
+    operationId: "getServiceStream",
+    produces: ["video/MP2T"],
+    responses: {
+        200: {
+            description: "OK",
+            headers: {
+                "X-Mirakurun-Tuner-User-ID": {
+                    type: "string"
+                }
+            }
+        },
+        404: {
+            description: "Not Found"
+        },
+        503: {
+            description: "Tuner Resource Unavailable"
+        },
+        default: {
+            description: "Unexpected Error"
+        }
+    }
 };
 
 get.apiDoc = {


### PR DESCRIPTION
一部のIPTVクライアントはストリーミングの前にHEADメソッドをリクエストしますが、
それらの処理が実装されていないためクライアントがスタックしてしまいます。