### PR TITLE
Doc: Change build directory for recpt1 from /tmp to /buildwork

### DIFF
--- a/doc/Platforms.md
+++ b/doc/Platforms.md
@@ -103,13 +103,15 @@ if !(type "recpt1" > /dev/null 2>&1); then
   apt-get update
   apt-get install -y --no-install-recommends git autoconf automake
 
-  cd /tmp
+  mkdir /buildwork
+  cd /buildwork
   git clone https://github.com/stz2012/recpt1.git
   cd recpt1/recpt1
   ./autogen.sh
   ./configure --prefix /opt
   make
   make install
+  rm -rf /buildwork
 fi
 
 recpt1 -v


### PR DESCRIPTION
## 概要
[doc/Platforms.md](doc/Platforms.md) の修正です。  
一部のイメージでは、`/tmp`が`noexec`でマウントされており、現状のサンプルの場合スタートアップ実行時に`./autogen.sh: Permission denied`でビルドに失敗してしまいます。

## 変更内容
 - `/tmp`ディレクトリの代わりに`/buildwork`ディレクトリを作成
 - `/buildwork`ディレクトリ内でビルドを行うように変更
 - `make install`後に`/buildwork`ディレクトリを削除
  
マージのご検討よろしくお願いいたします。